### PR TITLE
Make arguments keyword-only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ maintainers = [
 name = "satkit"
 readme = "README.md"
 requires-python = ">=3.9"
-version = "0.9"
+version = "0.10.0"
 
 dependencies = [
   "httpx",

--- a/satkit/interpolate_raw_uti.py
+++ b/satkit/interpolate_raw_uti.py
@@ -41,7 +41,7 @@ from icecream import ic
 from satkit.errors import UltrasoundInterpolationError
 
 
-def to_fan(scanline_data, angle=None, zero_offset=None, pix_per_mm=None,
+def to_fan(scanline_data, *, angle=None, zero_offset=None, pix_per_mm=None,
            num_vectors=None, magnify=1, reserve=1800, show_progress=False):
     """
     Generate interpolated images from scanline ultrasound data.
@@ -60,39 +60,44 @@ def to_fan(scanline_data, angle=None, zero_offset=None, pix_per_mm=None,
     """
     if len(scanline_data.shape) == 4:  # multiple RGB images
         if show_progress:
-            images = [
-                to_fan_2d(
-                    frame, angle, zero_offset, pix_per_mm, num_vectors,
-                    magnify, reserve)
-                for frame in tqdm(scanline_data, desc='Fanshape')]
+            images = [to_fan_2d(frame, angle=angle, zero_offset=zero_offset,
+                                pex_per_mm=pix_per_mm, num_vectors=num_vectors,
+                                magnify=magnify, reserve=reserve) for frame in
+                      tqdm(scanline_data, desc='Fanshape')]
         else:
-            images = [
-                to_fan_2d(
-                    frame, angle, zero_offset, pix_per_mm, num_vectors,
-                    magnify, reserve) for frame in scanline_data]
+            images = [to_fan_2d(frame, angle=angle, zero_offset=zero_offset,
+                                pix_per_mm=pix_per_mm, num_vectors=num_vectors,
+                                magnify=magnify, reserve=reserve) for frame in
+                      scanline_data]
     elif len(scanline_data.shape) == 3:
         if scanline_data.shape[-1] == 3:  # single RGB image
-            images = to_fan_2d(scanline_data, angle, zero_offset,
-                               pix_per_mm, num_vectors, magnify, reserve)
+            images = to_fan_2d(scanline_data, angle=angle,
+                               zero_offset=zero_offset, pix_per_mm=pix_per_mm,
+                               num_vectors=num_vectors, magnify=magnify,
+                               reserve=reserve)
         else:  # multiple grayscale images
             if show_progress:
-                images = [
-                    to_fan_2d(
-                        frame, angle, zero_offset, pix_per_mm, num_vectors,
-                        magnify, reserve)
-                    for frame in tqdm(scanline_data, desc='Fanshape')]
+                images = [to_fan_2d(frame, angle=angle,
+                                    zero_offset=zero_offset,
+                                    pix_per_mm=pix_per_mm,
+                                    num_vectors=num_vectors, magnify=magnify,
+                                    reserve=reserve) for frame in
+                          tqdm(scanline_data, desc='Fanshape')]
             else:
-                images = [
-                    to_fan_2d(
-                        frame, angle, zero_offset, pix_per_mm, num_vectors,
-                        magnify, reserve) for frame in scanline_data]
+                images = [to_fan_2d(frame, angle=angle,
+                                    zero_offset=zero_offset,
+                                    pix_per_mm=pix_per_mm,
+                                    num_vectors=num_vectors, magnify=magnify,
+                                    reserve=reserve) for frame in
+                          scanline_data]
     else:  # single grayscale image
-        images = to_fan_2d(scanline_data, angle, zero_offset, pix_per_mm,
-                           num_vectors, magnify, reserve)
+        images = to_fan_2d(scanline_data, angle=angle, zero_offset=zero_offset,
+                           pix_per_mm=pix_per_mm, num_vectors=num_vectors,
+                           magnify=magnify, reserve=reserve)
     return np.array(images)
 
 
-def to_fan_2d(img, angle=None, zero_offset=None, pix_per_mm=None,
+def to_fan_2d(img, *, angle=None, zero_offset=None, pix_per_mm=None,
               num_vectors=None, magnify=1, reserve=1800):
     """
     Transform a raw ultrasound image to a fanshaped image.
@@ -149,9 +154,8 @@ def to_fan_2d(img, angle=None, zero_offset=None, pix_per_mm=None,
     return img
 
 
-def ult_cart2pol(
-        output_coordinates, origin, num_of_vectors, angle, zero_offset,
-        pix_per_mm, grayscale):
+def ult_cart2pol(output_coordinates, origin, num_of_vectors, angle,
+                 zero_offset, pix_per_mm, grayscale):
     """
     Transform an ultrasound image from cartesian to polar coordinates.
 


### PR DESCRIPTION
This PR suggests making arguments in functions key-word only, if they are not self-explanatory by their value or not mandatory.

Here we did this for the functions in interplolate_raw_uti.py, but this can be extended to other functions as well.

These changes need more testing before a merge, but we want to evaluate first, if this change is acknowledged, before continuing. What do you think of making arguments keyword-only?

A further plus of kw-only arguments is, that we can change the order of the arguments later without breaking backward-compatibility. Nevertheless, the change as proposed here, is backward-incompatible.