### PR TITLE
Fixes the issue of kaiser and adds seaborn as dependency

### DIFF
--- a/environments/satkit_devel_conda_env.yaml
+++ b/environments/satkit_devel_conda_env.yaml
@@ -62,3 +62,4 @@ dependencies:
     # to use in development mode.
     - licenseheaders
     - icecream
+  - seaborn >= 0.13

--- a/satkit/audio_processing/audio_processing.py
+++ b/satkit/audio_processing/audio_processing.py
@@ -35,7 +35,8 @@ import logging
 
 # Numpy and scipy
 import numpy as np
-from scipy.signal import butter, filtfilt, kaiser, sosfilt
+from scipy.signal import butter, filtfilt, sosfilt
+from scipy.signal.windows import kaiser
 from icecream import ic
 
 _audio_logger = logging.getLogger('satkit.audio')

--- a/satkit/metrics/ofreg.py
+++ b/satkit/metrics/ofreg.py
@@ -52,7 +52,8 @@ from dipy.align.metrics import CCMetric, EMMetric, SSDMetric
 from matplotlib import animation
 from matplotlib.backends.backend_pdf import PdfPages
 from scipy import interpolate
-from scipy.signal import butter, filtfilt, kaiser, sosfilt
+from scipy.signal import butter, filtfilt, sosfilt
+from scipy.signal.windows import kaiser
 
 # local modules
 import satkit.data_import.AAA_recordings as satkit_import_AAA


### PR DESCRIPTION
kaiser
---------
- Changes scipy.signal to scipy.signal.windows to import kaiser in the following files:

    - satkit/audio_processing/audio_processing.py
    - satkit/metrics/ofreg.py

seaborn
------------
- Adds seaborn to envionment/satkit_devel_conda_env.yaml.
- seaborn was necessary to run ./satkit.py.
